### PR TITLE
Don’t warn about missing “kern” table

### DIFF
--- a/OTFontFileVal/OTFontVal.cs
+++ b/OTFontFileVal/OTFontVal.cs
@@ -904,12 +904,6 @@ namespace OTFontFileVal
                 {
                     if (!hmtxTable.IsMonospace(this) && !ContainsSymbolsOnly())
                     {
-                        if (GetDirectoryEntry("kern") == null)
-                        {
-                            v.Warning(T.T_NULL, W._FONT_W_MissingRecommendedTable, null, "kern");
-                            bMissing = true;
-                        }
-
                         if (GetDirectoryEntry("hdmx") == null)
                         {
                             v.Warning(T.T_NULL, W._FONT_W_MissingRecommendedTable, null, "hdmx");


### PR DESCRIPTION
The warning is not warranted since “kern” is by far a legacy table (not
counting Apple’s versions of it) and need not and should not be present
in new fonts.