### PR TITLE
Allow GSUB extension lookup tables to wrap reverse chaining lookup tables

### DIFF
--- a/OTFontFile/Table_GSUB.cs
+++ b/OTFontFile/Table_GSUB.cs
@@ -1847,7 +1847,7 @@ namespace OTFontFile
                     case 4: st = new Table_GSUB.LigatureSubst    (m_offsetExtensionSubst + ExtensionOffset, m_bufTable); break;
                     case 5: st = new Table_GSUB.ContextSubst     (m_offsetExtensionSubst + ExtensionOffset, m_bufTable); break;
                     case 6: st = new Table_GSUB.ChainContextSubst(m_offsetExtensionSubst + ExtensionOffset, m_bufTable); break;
-
+                    case 8: st = new Table_GSUB.ReverseChainSubst(m_offsetExtensionSubst + ExtensionOffset, m_bufTable); break;
                 }
                 if (st != null)
                 {

--- a/OTFontFileVal/val_GSUB.cs
+++ b/OTFontFileVal/val_GSUB.cs
@@ -1820,7 +1820,7 @@ namespace OTFontFileVal
                 }
 
                 // check the ExtensionLookupType
-                if (ExtensionLookupType >= 7)
+                if (ExtensionLookupType == 7 || ExtensionLookupType > 8)
                 {
                     v.Error(T.T_NULL, E.GSUB_E_ExtensionLookupType, table.m_tag, sIdentity + ", ExtensionLookupType = " + ExtensionLookupType);
                     bRet = false;
@@ -1848,6 +1848,7 @@ namespace OTFontFileVal
                     case 4: st = new val_GSUB.LigatureSubst_val    (m_offsetExtensionSubst + ExtensionOffset, m_bufTable); break;
                     case 5: st = new val_GSUB.ContextSubst_val     (m_offsetExtensionSubst + ExtensionOffset, m_bufTable); break;
                     case 6: st = new val_GSUB.ChainContextSubst_val(m_offsetExtensionSubst + ExtensionOffset, m_bufTable); break;
+                    case 8: st = new val_GSUB.ReverseChainSubst_val(m_offsetExtensionSubst + ExtensionOffset, m_bufTable); break;
 
                 }
                 if (st != null)


### PR DESCRIPTION
I haven't been able to find anything in the documentation that says GSUB extension lookup tables can't wrap reverse chaining lookup tables, but for some reason the code doesn't consider them when validating.