### PR TITLE
Update range of reserved name IDs

### DIFF
--- a/OTFontFileVal/val_name.cs
+++ b/OTFontFileVal/val_name.cs
@@ -145,7 +145,7 @@ namespace OTFontFileVal
 
                     if (nr != null)
                     {
-                        if (nr.NameID >= 21 && nr.NameID <= 255)
+                        if (nr.NameID >= 26 && nr.NameID <= 255)
                         {
                             string s = "platID = " + nr.PlatformID 
                                 + ", encID = " + nr.EncodingID


### PR DESCRIPTION
As of OpenType Version 1.8.3, name IDs 21 thru 25 are defined
https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids